### PR TITLE
Implicitly import x/net/http2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,33 +16,21 @@ them will return a "BadDeviceToken" or an "Unregistered" from time to time.
 ```
 
 # Getting started
-## Install the Go programming language
-See [here](https://golang.org/doc/install).
+### Install the Go programming language
+See [here](https://golang.org/doc/install). Be sure to install at least version 1.6.
 
-## Install the HTTP/2 library
-### Set your GOPATH
-By default, Go installs itself to /usr/local/go on a Mac:
-```
-$ export GOPATH=/usr/local/go/
-```
-
-### Install the library
-After exporting the GOPATH variable, install the HTTP/2 library:
-```
-$ go get golang.org/x/net/http2
-```
-
-## Generate your self signed certificate
+### Generate your self signed certificate
 Create a self signed certificate using one of Go's scripts:
 ```
 $ go run /usr/local/go/src/crypto/tls/generate_cert.go --host clevertap.com
 ```
 
-## Start the server
+### Start the server
 If you created the certificate elsewhere, you'll need to use the
-options -cert and -key to specify where the certificate and it's key are located
+options -cert and -key to specify where the certificate and its key are located.
 ```
-$ go run go-apns-server.go
+$ go build go-apns-server.go
+$ ./go-apns-server
 ```
 
 The default port is 8443, which can be changed by passing the -port argument

--- a/go-apns-server.go
+++ b/go-apns-server.go
@@ -7,13 +7,12 @@
 package main
 
 import (
-	"strconv"
 	"flag"
 	"fmt"
-	"golang.org/x/net/http2"
 	"log"
 	"math/rand"
 	"net/http"
+	"strconv"
 )
 
 func main() {
@@ -23,13 +22,8 @@ func main() {
 
 	flag.Parse()
 
-	var srv http.Server
-	http2.VerboseLogs = false
-	srv.Addr = ":" + strconv.Itoa(*serverPort)
-	http2.ConfigureServer(&srv, nil)
-
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		n := rand.Int31n(10);
+		n := rand.Int31n(10)
 
 		statusCode := 200
 
@@ -54,5 +48,7 @@ func main() {
 	log.Println("Using certificate", *serverCert, "with key", *serverKey)
 	log.Println("Starting server on port", *serverPort)
 	log.Println("Hit ctrl + c to stop...")
-	log.Fatal(srv.ListenAndServeTLS(*serverCert, *serverKey))
+
+	port := ":" + strconv.Itoa(*serverPort)
+	log.Fatal(http.ListenAndServeTLS(port, *serverCert, *serverKey, nil))
 }


### PR DESCRIPTION
With Go >= 1.6, net/http will use the x/net/http2 package as long as you
start the server with ListenAndServeTLS(). This commit removes the
explicit dependency on golang.org/x/net/http2 and modifies the README
to reflect that change.

If the simplicity of removing a step for the install outweighs the need to run http2 with VerboseLogs off, this will take care of that.
