### PR TITLE
read the request body to avoid goroutines blocking in the client

### DIFF
--- a/go-apns-server.go
+++ b/go-apns-server.go
@@ -9,6 +9,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -23,6 +24,10 @@ func main() {
 	flag.Parse()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Println("Error:", err)
+		}
 		n := rand.Int31n(10)
 
 		statusCode := 200


### PR DESCRIPTION
under load, not reading the request body causes clients to end up with goroutines stuck in `awaitFlowControl`.

https://github.com/adamvduke/await-flow-control
